### PR TITLE
MKObjects objectFromPFObject: ignores the PFObject properties

### DIFF
--- a/MKFoundation/Classes/MKFoundation/MKObject+ParseExtensions.m
+++ b/MKFoundation/Classes/MKFoundation/MKObject+ParseExtensions.m
@@ -74,6 +74,18 @@
   }
   
   NSObject *objcObject = [[klass alloc] init];
+  
+  NSArray *propertyArray = [[NSArray alloc] initWithObjects:@"objectId", @"updatedAt", @"createdAt", @"className", nil ];
+  [propertyArray enumerateObjectsUsingBlock:^(id property, NSUInteger idx, BOOL *stop) {
+    id value = [pfObject valueForKey:property];
+   
+    if([objcObject respondsToSelector:NSSelectorFromString(property)]) {
+        [objcObject setValue:[pfObject valueForKey:property] forKey:property];
+    }else{
+        NSLog(@"Class %@ doesn't define a property by name %@", [pfObject className], property);
+    }
+  }];
+  
   NSArray *keysArray = [pfObject allKeys];
   [keysArray enumerateObjectsUsingBlock:^(id key, NSUInteger idx, BOOL *stop) {
     


### PR DESCRIPTION
MKObject objectFromPFObject: now handles assigning known PFObject properties to a user defined object if the given property exists on the user defined MKObject. 

Example would be an object wanting to store the PFObject's objectId for future querying like the following:

[query whereKey:@"post"
        equalTo:[PFObject objectWithoutDataWithClassName:@"Post" objectId:@"1zEcyElZ80"]]
